### PR TITLE
fix(digest): Use Luna and Eastern issue dates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # OpenAI API key (required)
 OPENAI_API_KEY=sk-...
 
-# Model to use (default: gpt-5-mini)
-OPENAI_MODEL=gpt-5-mini
+# Model to use (default: gpt-5.6-luna)
+OPENAI_MODEL=gpt-5.6-luna
 OPENAI_TIMEOUT_SECONDS=60
 OPENAI_RETRIES=2
 DIGEST_OUTPUT_FILE=news.md

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -26,7 +26,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const today = new Date().toISOString().slice(0,10);
+            // Keep this aligned with src/publisher.py's America/New_York issue-date rule.
+            const digestDate = value =>
+              new Date(value).toLocaleDateString('en-CA', {
+                timeZone: 'America/New_York'
+              });
+            const today = digestDate(new Date());
             const query = `
               query($owner: String!, $repo: String!, $cursor: String) {
                 repository(owner: $owner, name: $repo) {
@@ -61,7 +66,7 @@ jobs:
               });
               const issues = result.repository.issues;
               existing = issues.nodes.find(issue =>
-                issue.createdAt.slice(0, 10) === today &&
+                digestDate(issue.createdAt) === today &&
                 issue.labels.nodes.some(label => label.name === 'ai-digest')
               );
               cursor = issues.pageInfo.endCursor;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ flowchart LR
         FEEDS[feeds.json]
         RSS[RSS feed endpoints]
         CONF[.env + config.py]
-        OAI[OpenAI API<br/>GitHub fallback]
+        OAI[OpenAI API<br/>manual graph path]
         MODEL[Codex / Claude model<br/>agent mode]
     end
 
@@ -37,7 +37,7 @@ flowchart LR
         ISSUE[GitHub Issue<br/>label: ai-digest]
     end
 
-    GH --> CHECK --> C
+    GH --> C
     AGENT --> CHECK
     LOCAL --> C
     FEEDS --> C
@@ -59,12 +59,12 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-    GH[GitHub Actions] --> T{Today's issue<br/>already open?}
+    GH[GitHub Actions<br/>manual digest] --> C[Collect + filter + build candidate groups]
     AGENT[Codex / Claude] --> T
     T -- Yes --> S[Stop]
-    T -- No --> C[Collect + filter + build candidate groups]
+    T -- No --> C
     C --> P{Path}
-    P -- GitHub Actions --> K1{OPENAI_API_KEY available?}
+    P -- GitHub manual --> K1{OPENAI_API_KEY available?}
     K1 -- Yes --> L[OpenAI dedupe + categorize]
     K1 -- No --> R[Local duplicate resolution + fallback categorization]
     P -- Codex / Claude --> X[Write digest-candidates.json]
@@ -92,5 +92,6 @@ flowchart LR
 - LLM request timeouts retry before falling back to local duplicate resolution.
 - The LLM receives candidate groups and returns structured duplicate clusters.
 - `--dispatch-publish` triggers `.github/workflows/publish-digest.yml` with a compressed digest payload; that workflow runs the repo-local `--publish-issue` path on GitHub Actions.
+- `.github/workflows/digest.yml` is manual-only. Manual dispatch skips its schedule-only preflight, runs the API graph, and rechecks the issue idempotently only when publishing.
 - Direct `--publish-issue` remains a manual fallback.
 - Short display titles are generated only for kept items after duplicates are resolved.

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,6 +15,8 @@ UV_CACHE_DIR=.uv-cache uv run python src/main.py
 
 Add `OPENAI_API_KEY` to `.env` if you want the default graph path to use OpenAI directly. Placeholder values such as `sk-...` or `your_api_key_here` are treated as missing.
 
+The default API model is `gpt-5.6-luna`. Set `OPENAI_MODEL` to override it.
+
 ## Agent-Driven Mode
 
 This path keeps feed collection and filtering in Python, then lets Codex or Claude Code write editorial decisions without needing `OPENAI_API_KEY`.
@@ -94,4 +96,4 @@ Optional fields:
 
 ## CI
 
-Push and pull request CI runs `pytest` and `mypy`. Scheduled agent runs generate locally and dispatch the final publish through GitHub Actions so the final issue author is `app/github-actions`.
+Push and pull request CI runs `pytest` and `mypy`. Scheduled agent runs generate locally and dispatch the final publish through GitHub Actions so the final issue author is `app/github-actions`. Publisher issue matching and generated title dates use `America/New_York`, so a delayed run does not shift the digest to the wrong calendar day.

--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,7 @@ def _get_env_int(name: str, default: int) -> int:
 
 # ── OpenAI ───────────────────────────────────────────────────────
 OPENAI_API_KEY: str = _get_env_str("OPENAI_API_KEY", "")
-OPENAI_MODEL: str = _get_env_str("OPENAI_MODEL", "gpt-5-mini")
+OPENAI_MODEL: str = _get_env_str("OPENAI_MODEL", "gpt-5.6-luna")
 OPENAI_TIMEOUT_SECONDS: int = _get_env_int("OPENAI_TIMEOUT_SECONDS", 60)
 OPENAI_RETRIES: int = _get_env_int("OPENAI_RETRIES", 2)
 DIGEST_OUTPUT_FILE: str = _get_env_str("DIGEST_OUTPUT_FILE", "news.md")

--- a/src/publisher.py
+++ b/src/publisher.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal, TypeVar, TypedDict
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from zoneinfo import ZoneInfo
 
 try:
     from config import (
@@ -40,6 +41,8 @@ _MAX_ISSUE_BODY_CHARS = 65_000
 _MAX_TITLE_STORY_CHARS = 100
 _MONTH_ABBREVS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
 _TOP_STORY_LINE_PATTERN = re.compile(r"^- \*\*\[(.+?)\]\(", re.MULTILINE)
+# Keep this aligned with the issue-date rule in .github/workflows/digest.yml.
+_DIGEST_TIME_ZONE = ZoneInfo("America/New_York")
 _OPEN_ISSUES_QUERY = """
 query($owner: String!, $repo: String!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
@@ -144,8 +147,12 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _digest_now() -> datetime:
+    return _utcnow().astimezone(_DIGEST_TIME_ZONE)
+
+
 def _today_title_base() -> str:
-    now = _utcnow()
+    now = _digest_now()
     return f"{DIGEST_ISSUE_TITLE_PREFIX} - {_MONTH_ABBREVS[now.month - 1]} {now.day}"
 
 
@@ -469,7 +476,13 @@ def check_issue_status() -> IssueStatusResult:
 
 def _issue_created_today(issue: dict[str, Any]) -> bool:
     created_at = str(issue.get("createdAt", ""))
-    return created_at[:10] == _utcnow().date().isoformat()
+    try:
+        created = datetime.fromisoformat(created_at)
+    except ValueError:
+        return False
+    if created.tzinfo is None:
+        return False
+    return created.astimezone(_DIGEST_TIME_ZONE).date() == _digest_now().date()
 
 
 def _issue_has_label(issue: dict[str, Any], label_name: str) -> bool:

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -210,6 +210,40 @@ def test_check_issue_status_reports_missing_issue(monkeypatch):
     }
 
 
+def test_issue_created_today_uses_eastern_day_for_delayed_run(monkeypatch):
+    monkeypatch.setattr(
+        publisher,
+        "_utcnow",
+        lambda: datetime(2026, 8, 28, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert publisher._issue_created_today(
+        {"createdAt": "2026-08-27T15:05:21Z"}
+    )
+
+
+def test_issue_created_today_rejects_previous_eastern_day_after_midnight(monkeypatch):
+    monkeypatch.setattr(
+        publisher,
+        "_utcnow",
+        lambda: datetime(2026, 8, 28, 4, 1, tzinfo=timezone.utc),
+    )
+
+    assert not publisher._issue_created_today(
+        {"createdAt": "2026-08-28T03:59:00Z"}
+    )
+
+
+def test_today_title_base_uses_eastern_day(monkeypatch):
+    monkeypatch.setattr(
+        publisher,
+        "_utcnow",
+        lambda: datetime(2026, 8, 28, 1, 15, tzinfo=timezone.utc),
+    )
+
+    assert publisher._today_title_base() == "Biotech / Pharma Headlines - Aug 27"
+
+
 def test_publish_issue_creates_new_issue(tmp_path, monkeypatch):
     news_file = tmp_path / "news.md"
     news_file.write_text("hello world", encoding="utf-8")


### PR DESCRIPTION
## Summary
- default the API graph and setup example to gpt-5.6-luna
- use America/New_York for publisher issue matching and generated title dates
- add Eastern-midnight regressions and align the dormant workflow helper
- document the current manual-only GitHub API path accurately

## Scope
This PR does not restore the scheduled GitHub fallback or change the current local Codex automation. A follow-up PR will add the guarded schedule and fail-closed OpenAI behavior.

## Test plan
- [x] UV_CACHE_DIR=.uv-cache uv sync --locked --extra dev
- [x] UV_CACHE_DIR=.uv-cache uv run pytest -q (123 passed)
- [x] UV_CACHE_DIR=.uv-cache uv run mypy src
- [x] GitHub workflow YAML parsing
- [x] Node replay of both Eastern-midnight boundary cases
- [x] git diff --check